### PR TITLE
Update to use latest pages-service

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -30,6 +30,8 @@ services:
     pps.mapper_factory:
         class: BBC\ProgrammesPagesService\Mapper\ProgrammesDbToDomain\MapperFactory
         public: false
+        arguments:
+            - core_entity_inherit_master_brand: false
 
     pps.service_factory:
         class: BBC\ProgrammesPagesService\Service\ServiceFactory

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">=7.1.0",
         "aws/aws-sdk-php": "^3.0",
         "bbc-rmp/cloudwatch-monitoringhandler": "^1.0",
-        "bbc/programmes-pages-service": "^2.0",
+        "bbc/programmes-pages-service": "^2.6",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed08c617c144550a0c147c07e7dccd3c",
+    "content-hash": "6f564afb58b76f6dd5aa1cee6adbcd08",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -221,16 +221,16 @@
         },
         {
             "name": "bbc/programmes-pages-service",
-            "version": "v2.1.2",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/programmes-pages-service.git",
-                "reference": "a9b5fdbe0819363737c49eb4199c19e68b86366c"
+                "reference": "fd1e9c04657722f1c05706583fefabd7969d77b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/a9b5fdbe0819363737c49eb4199c19e68b86366c",
-                "reference": "a9b5fdbe0819363737c49eb4199c19e68b86366c",
+                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/fd1e9c04657722f1c05706583fefabd7969d77b0",
+                "reference": "fd1e9c04657722f1c05706583fefabd7969d77b0",
                 "shasum": ""
             },
             "require": {
@@ -242,11 +242,16 @@
                 "symfony/stopwatch": "^3.2"
             },
             "require-dev": {
+                "cakephp/chronos": "^1.1",
                 "doctrine/data-fixtures": "^1.2",
                 "escapestudios/symfony2-coding-standard": "^2.9",
+                "phpstan/phpstan": "^0.8.0",
                 "phpunit/phpunit": "^6.1",
                 "squizlabs/php_codesniffer": "^2.9",
                 "symfony/cache": "^3.2"
+            },
+            "suggest": {
+                "cakephp/chronos": "If you would like to use UtcDateTimeType"
             },
             "type": "library",
             "autoload": {
@@ -264,10 +269,10 @@
             ],
             "description": "A library for building /programmes pages",
             "support": {
-                "source": "https://github.com/bbc/programmes-pages-service/tree/v2.1.2",
+                "source": "https://github.com/bbc/programmes-pages-service/tree/v2.6.0",
                 "issues": "https://github.com/bbc/programmes-pages-service/issues"
             },
-            "time": "2017-05-24T15:52:35+00:00"
+            "time": "2017-08-10T11:42:07+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -2576,12 +2581,12 @@
             "version": "2.10.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/djoos/Symfony2-coding-standard.git",
+                "url": "https://github.com/djoos/Symfony-coding-standard.git",
                 "reference": "fdf8de2c4de016abb5ea6b6015f80c47f1f6301b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/djoos/Symfony2-coding-standard/zipball/fdf8de2c4de016abb5ea6b6015f80c47f1f6301b",
+                "url": "https://api.github.com/repos/djoos/Symfony-coding-standard/zipball/fdf8de2c4de016abb5ea6b6015f80c47f1f6301b",
                 "reference": "fdf8de2c4de016abb5ea6b6015f80c47f1f6301b",
                 "shasum": ""
             },

--- a/tests/ApsMapper/AtozItemMapperTest.php
+++ b/tests/ApsMapper/AtozItemMapperTest.php
@@ -8,6 +8,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Brand;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Mid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Nid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
@@ -38,13 +39,14 @@ class AtozItemMapperTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             null, // Parent
             3,
             new MasterBrand(
                 new Mid('bbc_one'),
                 'BBC One',
                 $mbImage,
-                new Network(new Nid('bbc_one'), 'BBC One', $mbImage, 'bbcone', 'tv', 'tv')
+                new Network(new Nid('bbc_one'), 'BBC One', $mbImage, new Options(), 'bbcone', 'tv', 'tv')
             ),
             [],
             [],

--- a/tests/ApsMapper/ChildrenSeriesOfContainerMapperTest.php
+++ b/tests/ApsMapper/ChildrenSeriesOfContainerMapperTest.php
@@ -4,6 +4,7 @@ namespace Tests\BBC\CliftonBundle\ApsMapper;
 
 use BBC\CliftonBundle\ApsMapper\ChildrenSeriesOfContainerMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Series;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
@@ -34,6 +35,7 @@ class ChildrenSeriesOfContainerMapperTest extends TestCase
             5,
             6,
             false,
+            new Options(),
             null,
             7,
             null,

--- a/tests/ApsMapper/FindByPidProgrammeMapperAdditionalHydrationTest.php
+++ b/tests/ApsMapper/FindByPidProgrammeMapperAdditionalHydrationTest.php
@@ -8,6 +8,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Brand;
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Series;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\RelatedLink;
 use BBC\ProgrammesPagesService\Domain\Entity\Version;
 use BBC\ProgrammesPagesService\Domain\Entity\VersionType;
@@ -76,6 +77,7 @@ class FindByPidProgrammeMapperAdditionalHydrationTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             null,
             2101,
             null,
@@ -103,6 +105,7 @@ class FindByPidProgrammeMapperAdditionalHydrationTest extends TestCase
             1301,
             1302,
             1303,
+            new Options(),
             null,
             2101,
             null,

--- a/tests/ApsMapper/FindByPidProgrammeMapperTest.php
+++ b/tests/ApsMapper/FindByPidProgrammeMapperTest.php
@@ -12,6 +12,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Series;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Mid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Nid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
@@ -45,6 +46,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             null,
             2101,
             null,
@@ -101,6 +103,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             null,
             2101,
             null,
@@ -129,6 +132,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             $brand,
             2101,
             null,
@@ -201,6 +205,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             1301,
             1302,
             1303,
+            new Options(),
             null,
             2101,
             null,
@@ -259,6 +264,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             1103,
             MediaTypeEnum::VIDEO,
             1201,
+            new Options(),
             null,
             2101,
             null,
@@ -560,6 +566,7 @@ class FindByPidProgrammeMapperTest extends TestCase
                 new Nid('bbc_radio_one'),
                 'BBC Radio 1',
                 new Image(new Pid('p01tqv8z'), 'Title', 'ShortSynopsis', 'ShortSynopsis', 'standard', 'jpg'),
+                new Options(),
                 'radio1',
                 'National Radio',
                 'radio'
@@ -593,6 +600,7 @@ class FindByPidProgrammeMapperTest extends TestCase
                 new Nid('bbc_radio_one'),
                 'BBC Radio 1',
                 new Image(new Pid('p01tqv8z'), 'Title', 'ShortSynopsis', 'ShortSynopsis', 'standard', 'jpg'),
+                new Options(),
                 null,
                 'National Radio',
                 ''
@@ -626,6 +634,7 @@ class FindByPidProgrammeMapperTest extends TestCase
                 new Nid('bbc_one'),
                 'BBC One',
                 new Image(new Pid('p01tqv8z'), 'Title', 'ShortSynopsis', 'ShortSynopsis', 'standard', 'jpg'),
+                new Options(),
                 'bbc_one',
                 'TV',
                 'tv'
@@ -674,6 +683,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             0,
             0,
             false,
+            new Options(),
             null,
             101,
             new MasterBrand(
@@ -684,6 +694,7 @@ class FindByPidProgrammeMapperTest extends TestCase
                     new Nid('bbc_two'),
                     'BBC Two',
                     new Image(new Pid('p01tqv8z'), 'Title', 'ShortSynopsis', 'ShortSynopsis', 'standard', 'jpg'),
+                    new Options(),
                     'bbc_two',
                     'TV',
                     'tv'
@@ -714,6 +725,7 @@ class FindByPidProgrammeMapperTest extends TestCase
             0,
             0,
             false,
+            new Options(),
             $brand,
             101,
             new MasterBrand(
@@ -724,6 +736,7 @@ class FindByPidProgrammeMapperTest extends TestCase
                     new Nid('bbc_one'),
                     'BBC One',
                     new Image(new Pid('p01tqv8z'), 'Title', 'ShortSynopsis', 'ShortSynopsis', 'standard', 'jpg'),
+                    new Options(),
                     'bbc_one',
                     'TV',
                     'tv'

--- a/tests/ApsMapper/FindByPidSegmentEventMapperAdditionalHydrationTest.php
+++ b/tests/ApsMapper/FindByPidSegmentEventMapperAdditionalHydrationTest.php
@@ -9,6 +9,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Segment;
 use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
 use BBC\ProgrammesPagesService\Domain\Entity\Version;
@@ -250,6 +251,7 @@ class FindByPidSegmentEventMapperAdditionalHydrationTest extends TestCase
                 new Nid('bbc_1xtra'),
                 'BBC Radio 1Xtra',
                 new Image(new Pid('p01gdp18'), '', '', '', '', ''),
+                new Options(),
                 '1xtra',
                 'National Radio'
             )

--- a/tests/ApsMapper/FindByPidSegmentEventMapperTest.php
+++ b/tests/ApsMapper/FindByPidSegmentEventMapperTest.php
@@ -5,6 +5,7 @@ namespace Tests\BBC\CliftonBundle\ApsMapper;
 use BBC\CliftonBundle\ApsMapper\FindByPidSegmentEventMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Segment;
 use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
 use BBC\ProgrammesPagesService\Domain\Entity\Version;
@@ -39,7 +40,8 @@ class FindByPidSegmentEventMapperTest extends TestCase
                     0,
                     0,
                     1,
-                    0
+                    0,
+                    new Options()
                 ),
                 true,
                 true,

--- a/tests/ApsMapper/FindByPidSegmentMapperAdditionalHydrationTest.php
+++ b/tests/ApsMapper/FindByPidSegmentMapperAdditionalHydrationTest.php
@@ -8,6 +8,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Segment;
 use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
 use BBC\ProgrammesPagesService\Domain\Entity\Version;
@@ -78,7 +79,8 @@ class FindByPidSegmentMapperAdditionalHydrationTest extends TestCase
                         0,
                         0,
                         0,
-                        0
+                        0,
+                        new Options()
                     ),
                     false,
                     false,
@@ -178,6 +180,7 @@ class FindByPidSegmentMapperAdditionalHydrationTest extends TestCase
                 new Nid('bbc_1xtra'),
                 'BBC Radio 1Xtra',
                 new Image(new Pid('p01gdp18'), '', '', '', '', ''),
+                new Options(),
                 '1xtra',
                 'National Radio'
             )

--- a/tests/ApsMapper/MusicArtistsMapperTest.php
+++ b/tests/ApsMapper/MusicArtistsMapperTest.php
@@ -9,6 +9,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\MasterBrand;
 use BBC\ProgrammesPagesService\Domain\Entity\MusicSegment;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Segment;
 use BBC\ProgrammesPagesService\Domain\Entity\SegmentEvent;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedImage;
@@ -194,6 +195,7 @@ class MusicArtistsMapperTest extends TestCase
             0,
             0,
             false,
+            new Options(),
             null,
             null,
             $masterBrand
@@ -217,6 +219,7 @@ class MusicArtistsMapperTest extends TestCase
             0,
             0,
             0,
+            new Options(),
             $brand
         );
 

--- a/tests/ApsMapper/MusicChartNetworkMapperTest.php
+++ b/tests/ApsMapper/MusicChartNetworkMapperTest.php
@@ -4,6 +4,7 @@ namespace Tests\BBC\CliftonBundle\ApsMapper;
 
 use BBC\CliftonBundle\ApsMapper\MusicChartNetworkMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Unfetched\UnfetchedImage;
 use BBC\ProgrammesPagesService\Domain\Enumeration\NetworkMediumEnum;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Nid;
@@ -20,6 +21,7 @@ class MusicChartNetworkMapperTest extends TestCase
             new Nid('bbc_radio_two'),
             $title,
             new UnfetchedImage(),
+            new Options(),
             $urlKey,
             'National Radio',
             NetworkMediumEnum::RADIO

--- a/tests/ApsMapper/ProgrammeChildrenProgrammeMapperTest.php
+++ b/tests/ApsMapper/ProgrammeChildrenProgrammeMapperTest.php
@@ -6,6 +6,7 @@ use BBC\ProgrammesPagesService\Domain\Enumeration\MediaTypeEnum;
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Series;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\PartialDate;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
@@ -37,6 +38,7 @@ class ProgrammeChildrenProgrammeMapperTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             null,
             2101,
             null,
@@ -88,6 +90,7 @@ class ProgrammeChildrenProgrammeMapperTest extends TestCase
             1301,
             1302,
             1303,
+            new Options(),
             null,
             2101,
             null,

--- a/tests/ApsMapper/TleosSliceByCategoryMapperTest.php
+++ b/tests/ApsMapper/TleosSliceByCategoryMapperTest.php
@@ -5,6 +5,7 @@ namespace Tests\BBC\CliftonBundle\ApsMapper;
 use BBC\CliftonBundle\ApsMapper\TleosSliceByCategoryMapper;
 use BBC\ProgrammesPagesService\Domain\Entity\Genre;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Synopses;
 use BBC\ProgrammesPagesService\Domain\Entity\Series;
@@ -79,6 +80,7 @@ class TleosSliceByCategoryMapperTest extends TestCase
             1204,
             1205,
             false,
+            new Options(),
             null,
             2101,
             null,

--- a/tests/ApsMapper/Traits/CollapsedBroadcastTrait.php
+++ b/tests/ApsMapper/Traits/CollapsedBroadcastTrait.php
@@ -6,6 +6,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\CollapsedBroadcast;
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Series;
 use BBC\ProgrammesPagesService\Domain\Entity\Service;
 use BBC\ProgrammesPagesService\Domain\Enumeration\MediaTypeEnum;
@@ -39,6 +40,7 @@ trait CollapsedBroadcastTrait
             1301,
             1302,
             1303,
+            new Options(),
             $series,
             2101,
             null,
@@ -65,6 +67,7 @@ trait CollapsedBroadcastTrait
                 'type',
                 'jpg'
             ),
+            new Options(),
             'network' . $id,
             'audio',
             NetworkMediumEnum::TV
@@ -104,7 +107,8 @@ trait CollapsedBroadcastTrait
             0,
             1,
             1,
-            true
+            true,
+            new Options()
         );
     }
 

--- a/tests/Controller/FindByPidControllerTest.php
+++ b/tests/Controller/FindByPidControllerTest.php
@@ -27,6 +27,10 @@ class FindByPidControllerTest extends BaseWebTestCase
         // Parent tree
         $this->assertArrayNotHasKey('parent', $jsonContent['programme']);
 
+        // Ownership
+        $this->assertArrayHasKey('ownership', $jsonContent['programme']);
+        $this->assertEquals('bbc_one', $jsonContent['programme']['ownership']['service']['id']);
+
         // Siblings
         $this->assertArrayNotHasKey('peers', $jsonContent['programme']);
 
@@ -53,6 +57,10 @@ class FindByPidControllerTest extends BaseWebTestCase
         // Parent tree
         $this->assertEquals('b006m86d', $jsonContent['programme']['parent']['programme']['pid']);
         $this->assertArrayNotHasKey('parent', $jsonContent['programme']['parent']);
+
+        // Ownership does not inherit
+        $this->assertArrayNotHasKey('ownership', $jsonContent['programme']);
+        $this->assertEquals('bbc_one', $jsonContent['programme']['parent']['programme']['ownership']['service']['id']);
 
         // Siblings
         $this->assertNull($jsonContent['programme']['peers']['next']);
@@ -85,6 +93,11 @@ class FindByPidControllerTest extends BaseWebTestCase
         $this->assertEquals('b006m86f', $jsonContent['programme']['parent']['programme']['pid']);
         $this->assertEquals('b006m86d', $jsonContent['programme']['parent']['programme']['parent']['programme']['pid']);
         $this->assertArrayNotHasKey('parent', $jsonContent['programme']['parent']['programme']['parent']);
+
+        // Ownership does not inherit
+        $this->assertArrayNotHasKey('ownership', $jsonContent['programme']);
+        $this->assertEquals('bbc_one', $jsonContent['programme']['parent']['programme']['parent']['programme']['ownership']['service']['id']);
+
 
         // Related links
         $this->assertSame([], $jsonContent['programme']['links']);
@@ -119,6 +132,11 @@ class FindByPidControllerTest extends BaseWebTestCase
         $this->assertEquals('b006m86f', $jsonContent['programme']['parent']['programme']['parent']['programme']['pid']);
         $this->assertEquals('b006m86d', $jsonContent['programme']['parent']['programme']['parent']['programme']['parent']['programme']['pid']);
         $this->assertArrayNotHasKey('parent', $jsonContent['programme']['parent']['programme']['parent']['programme']['parent']);
+
+        // Ownership does not inherit
+        $this->assertArrayNotHasKey('ownership', $jsonContent['programme']);
+        $this->assertEquals('bbc_one', $jsonContent['programme']['parent']['programme']['parent']['programme']['parent']['programme']['ownership']['service']['id']);
+
 
         // Related links
         $this->assertSame([], $jsonContent['programme']['links']);

--- a/tests/DataFixtures/ORM/EastendersFixture.php
+++ b/tests/DataFixtures/ORM/EastendersFixture.php
@@ -11,6 +11,8 @@ use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Episode;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Clip;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Series;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Image;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\MasterBrand;
+use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Network;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\RelatedLink;
 use BBC\ProgrammesPagesService\Data\ProgrammesDb\Entity\Version;
 use BBC\ProgrammesPagesService\Domain\ValueObject\PartialDate;
@@ -20,12 +22,17 @@ class EastendersFixture extends AbstractFixture
 {
     public function load(ObjectManager $manager)
     {
+        $network = new Network('bbc_one', 'BBC One');
+        $masterBrand = new MasterBrand('bbc_one', 'p01y7bvp', 'BBC One');
+        $masterBrand->setNetwork($network);
+
         $image = new Image('p01m5mss', 'Image Title');
         $image->setShortSynopsis('Image Synopsis');
         $image->setType('standard');
         $image->setExtension('jpg');
 
         $brand = new Brand('b006m86d', 'Eastenders');
+        $brand->setMasterBrand($masterBrand);
         $brand->setAvailableClipsCount(2);
         $brand->setRelatedLinksCount(2);
 
@@ -84,6 +91,8 @@ class EastendersFixture extends AbstractFixture
         $relatedLink2 = new RelatedLink('b06khps2', 'RL1', 'http://example.com', 'standard', $brand, true);
 
         foreach ([
+                     $network,
+                     $masterBrand,
                      $image,
                      $brand,
                      $series,


### PR DESCRIPTION
This change accounts for changes in how MasterBrands are inherited in
pages-service. The end result is no change in Clifton output.

* Add core_entity_inherit_master_brand = false to MapperFactory config
* Update tests to fail if core_entity_inherit_master_brand is not false
* Update tests to account for Options needing to be passed into
  Programmes and Networks