### PR TITLE
PROGRAMMES-5832 improve status check

### DIFF
--- a/src/Controller/StatusController.php
+++ b/src/Controller/StatusController.php
@@ -3,6 +3,8 @@
 namespace BBC\CliftonBundle\Controller;
 
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Sid;
+use DateTimeImmutable;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -61,8 +63,23 @@ class StatusController extends Controller
     private function verifyNoDatabaseCacheIssues(): bool
     {
         try {
-            $pid = new Pid('b006m86d'); //Eastenders
-            $this->get('pps.programmes_service')->findByPidFull($pid);
+            // Eastenders clip
+            $clipPid = new Pid('p04r0jcv');
+            $this->get('pps.programmes_service')->findByPidFull($clipPid);
+
+            // Broadcast
+            $fromDateTime = new DateTimeImmutable('2010-01-15 06:00:00');
+            $toDatetime = new DateTimeImmutable('2017-10-16 06:00:00');
+            $sid = new Sid('bbc_radio_two');
+            $this->get('pps.broadcasts_service')->findByServiceAndDateRange($sid, $fromDateTime, $toDatetime, 1, 1);
+
+            // Version
+            $versionPid = new Pid('b00000p6');
+            $this->get('pps.versions_service')->findByPidFull($versionPid);
+
+            // Segment event
+            $segmentPid = new Pid('p002d80x');
+            $this->get('pps.segment_events_service')->findByPidFull($segmentPid);
         } catch (ConnectionExceptionDBAL | ConnectionException $e) {
             return true;
         } catch (PDOException $e) {

--- a/tests/Controller/StatusControllerTest.php
+++ b/tests/Controller/StatusControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\BBC\CliftonBundle\Controller;
 
-use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Service\BroadcastsService;
 use BBC\ProgrammesPagesService\Service\ProgrammesService;
+use BBC\ProgrammesPagesService\Service\SegmentEventsService;
+use BBC\ProgrammesPagesService\Service\VersionsService;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DBALException;
 use Tests\BBC\CliftonBundle\BaseWebTestCase;
@@ -35,13 +37,28 @@ class StatusControllerTest extends BaseWebTestCase
         $client = static::createClient([], [
             'HTTP_USER_AGENT' => 'ELB-HealthChecker/1.0',
         ]);
-        // Create mock service to throw exception and inject into container
-        $mockService = $this->createMockProgrammesService();
-        $mockService->expects($this->once())
+
+        // clip mock
+        $mockProgrammeService = $this->createMockProgrammesService();
+        $mockProgrammeService->expects($this->once())->method('findByPidFull');
+        $client->getContainer()->set('pps.programmes_service', $mockProgrammeService);
+
+        // broadcast service mock
+        $mockBroadcastService = $this->createMock(BroadcastsService::class);
+        $mockBroadcastService->expects($this->once())->method('findByServiceAndDateRange');
+        $client->getContainer()->set('pps.broadcasts_service', $mockBroadcastService);
+
+        // version mock
+        $mockVersionService = $this->createMock(VersionsService::class);
+        $mockVersionService->expects($this->once())->method('findByPidFull');
+        $client->getContainer()->set('pps.versions_service', $mockVersionService);
+
+        // segment events mock. This one throw an exception and injects it into the container
+        $mockSegmentEventsService = $this->createMock(SegmentEventsService::class);
+        $mockSegmentEventsService->expects($this->once())
             ->method('findByPidFull')
-            ->with(new Pid('b006m86d'))
             ->willThrowException(new DBALException("Something bad happened."));
-        $client->getContainer()->set('pps.programmes_service', $mockService);
+        $client->getContainer()->set('pps.segment_events_service', $mockSegmentEventsService);
 
         $client->request('GET', '/status');
 
@@ -54,13 +71,28 @@ class StatusControllerTest extends BaseWebTestCase
         $client = static::createClient([], [
             'HTTP_USER_AGENT' => 'ELB-HealthChecker/1.0',
         ]);
-        // Create mock service to throw exception and inject into container
-        $mockService = $this->createMockProgrammesService();
-        $mockService->expects($this->once())
+
+        // clip mock
+        $mockProgrammeService = $this->createMockProgrammesService();
+        $mockProgrammeService->expects($this->once())->method('findByPidFull');
+        $client->getContainer()->set('pps.programmes_service', $mockProgrammeService);
+
+        // broadcast service mock
+        $mockBroadcastService = $this->createMock(BroadcastsService::class);
+        $mockBroadcastService->expects($this->once())->method('findByServiceAndDateRange');
+        $client->getContainer()->set('pps.broadcasts_service', $mockBroadcastService);
+
+        // version mock
+        $mockVersionService = $this->createMock(VersionsService::class);
+        $mockVersionService->expects($this->once())->method('findByPidFull');
+        $client->getContainer()->set('pps.versions_service', $mockVersionService);
+
+        // segment events mock. This one throw an exception and injects it into the container
+        $mockSegmentEventsService = $this->createMock(SegmentEventsService::class);
+        $mockSegmentEventsService->expects($this->once())
             ->method('findByPidFull')
-            ->with(new Pid('b006m86d'))
             ->willThrowException(new ConnectionException("Cannot Connect."));
-        $client->getContainer()->set('pps.programmes_service', $mockService);
+        $client->getContainer()->set('pps.segment_events_service', $mockSegmentEventsService);
 
         $client->request('GET', '/status');
 


### PR DESCRIPTION
Previously the status check only check if a brand page was working fine, now I have replaced this check with a couple of object with a bigger coverage in case of data corruption.

List of items created now:
- Clip
- Version
- Broadcast
- Segment events

I couldn't see any performance impact by adding this extra check.